### PR TITLE
Better compression for model poses

### DIFF
--- a/hosted/WorldChat.html
+++ b/hosted/WorldChat.html
@@ -158,7 +158,7 @@ var imports = url_params.get("import") ? url_params.get("import").split(',') : [
 
 var tools  ; // a map containing several things above so execution modes can access them
 
-var preload_meshes = ["default_avatar", "default_world","default_skybox","alternate_avatar"/*, "avatar_4", "dragon"*/] ;
+var preload_meshes = ["default_avatar", "default_world","default_skybox",/*"alternate_avatar", "avatar_4", "dragon"*/] ;
 
 function canvasApp() {
     //The canvas this app is running on.

--- a/hosted/WorldChatMode.js
+++ b/hosted/WorldChatMode.js
@@ -32,7 +32,7 @@ class WorldChatMode extends ExecutionMode{
 
     my_name = "player " + Math.floor(Math.random() * 1000000000) ;
     my_avatar = "default_avatar" ;
-    avatars = ["default_avatar","alternate_avatar"/*, "avatar_4"*/];
+    avatars = ["default_avatar"/*,"alternate_avatar", "avatar_4"*/];
     avatar_id = 0 ;
     my_mesh_id = -1;
     last_avatar_change = 0 ;

--- a/server/include/TimelineServer.h
+++ b/server/include/TimelineServer.h
@@ -45,6 +45,9 @@ class TimelineServer {
 
         static long timeMilliseconds();
 
+        static int bytes_in ;
+        static int bytes_out ;
+
   private:
 
     // See https://wiki.mozilla.org/Security/Server_Side_TLS for more details about

--- a/server/source/Main.cpp
+++ b/server/source/Main.cpp
@@ -32,11 +32,11 @@ void runUnitTests(){
 void loadModels(unordered_map<string, Variant>& table){
     map<string,string> models ;
     models["default_avatar"] = "./models/default_avatar.vrm";
-    models["alternate_avatar"] = "./models/alternate_avatar.vrm";
-    models["avatar_3"] = "./models/avatar_3.vrm";
-    models["avatar_4"] = "./models/avatar_4.vrm";
+    //models["alternate_avatar"] = "./models/alternate_avatar.vrm";
+    //models["avatar_3"] = "./models/avatar_3.vrm";
+    //models["avatar_4"] = "./models/avatar_4.vrm";
     models["eroom"] = "./models/room.glb";
-    models["dragon"] = "./models/dragon.glb";
+    //models["dragon"] = "./models/dragon.glb";
     models["bunny"] = "./models/bunny350.glb";
     models["default_world"] = "./models/default_world.glb";
     models["default_skybox"] = "./models/default_skybox.glb";
@@ -392,11 +392,22 @@ int main(int argc, const char** argv) {
     
     timeline->auto_clear_history = true;
     timeline->observable_interpolation = false;
+    long last_network_print_time = timeMilliseconds() ;
     while (running) {
         //animateDragon(timeline, 20, vec3(0,15,0), 20, 0.7);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         timeline->run();
         TimelineServer::quickForwardEvents();
+
+        long time = timeMilliseconds() ;
+        if(time > last_network_print_time + 10000){
+          float sent = TimelineServer::bytes_out/(1000.0f*(time - last_network_print_time)) ;
+          float got = TimelineServer::bytes_in/(1000.0f*(time - last_network_print_time)) ;
+          TimelineServer::bytes_out = 0;
+          TimelineServer::bytes_in = 0 ;
+          printf("Timeline: Sent: %f MB/s Received %f MB/s\n", sent, got);
+          last_network_print_time = time ;
+        }
     }
     //web_server.stop();
     timeline_server.stop();

--- a/wasm/include/Timeline.h
+++ b/wasm/include/Timeline.h
@@ -37,16 +37,16 @@ class Timeline{
         long last_sync_time = 0;
         int ping = 0;
         double ping_clock_adjustment = 0 ; // how much we're currently offsetting our clock from the server to adjust for ping (client only)
-        double ping_change_per_sync = 0.001; // how much we can change the ping adjustment per sync
+        double ping_change_per_sync = 0.002; // how much we can change the ping adjustment per sync
         double last_clear_time = -99999 ;
         bool just_reset = true;
 
-        double base_age = 0.1; // how long in the past to pull instants for synchronization
-        double history_kept = 0.5; // how much history to keep in seconds
+        double base_age = 0.2; // how long in the past to pull instants for synchronization
+        double history_kept = 0.7; // how much history to keep in seconds
         double max_time_warp = 0.05 ;
         bool auto_clear_history = false; // when true history will be cleared to timekept on event running when it reaches 2*time kept
         bool observable_interpolation = false; // whether we're calling getObserved on objects or just returning their current value
-        int object_updates_to_trigger_reset = 4; // if a nonempty timeline receives this many object updates in a sync packet, reset the whole timeline
+        int object_updates_to_trigger_reset = 6; // if a nonempty timeline receives this many object updates in a sync packet, reset the whole timeline
 
         std::recursive_mutex lock ;
 

--- a/wasm/include/Variant.h
+++ b/wasm/include/Variant.h
@@ -232,6 +232,8 @@ This function detects what type came in and converts it to a 32 bit float */
 
     static inline uint32_t murmurscramble(uint32_t k);
 
+    void makeFillableByteArray(int size);
+
     void makeFillableIntArray(int size);
 
     void makeFillableFloatArray(int size);

--- a/wasm/source/Variant.cpp
+++ b/wasm/source/Variant.cpp
@@ -1131,6 +1131,15 @@ uint32_t Variant::murmur(const uint8_t* key, size_t len, uint32_t seed) {
     return h;
 }
 
+void Variant::makeFillableByteArray(int size){
+    if(type_ != NULL_VARIANT){
+        free(ptr);
+    }
+    type_ = Variant::BYTE_ARRAY ;
+    ptr = (byte*) malloc(4 + size) ;
+    *(int*)(ptr) = size ;
+}
+
 void Variant::makeFillableIntArray(int size){
     if(type_ != NULL_VARIANT){
         free(ptr);

--- a/wasm/source/api.cpp
+++ b/wasm/source/api.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <ctime>
 #include <memory>
+#include <math.h>
 #include "glm/vec3.hpp"
 #include "TableInterface.h"
 #include "UnitTests.h"
@@ -454,17 +455,24 @@ byte* setPinTarget(byte* ptr) {
         }else{
             target = p ; // no ray, target is point given
         }
-        model->setPinTarget(name, target);
+        if(!isnan(target.x) && !isnan(target.y) && !isnan(target.z)){
+            model->setPinTarget(name, target);
+        }
     }
    
     if(obj["o"].defined()){
         float* vm = obj["o"].getFloatArray();
         glm::mat4 m ;
+        bool has_nan = false;
         for(int k=0;k<16;k++){
             *(((float*)&m)+k) = vm[k] ;
+            has_nan = has_nan || isnan(vm[k]);
         }
-        glm::quat rot_target = glm::quat_cast(m) ;
-        model->setPinTarget(name, rot_target);
+        if(!has_nan){
+            glm::quat rot_target = glm::quat_cast(m) ;
+            rot_target = glm::normalize(rot_target);
+            model->setPinTarget(name, rot_target);
+        }
     }
 
     //model->applyPins();


### PR DESCRIPTION
Quaternions for compressed model poses (primarily used for player IK) are now even more compressed, using shorts instead of floats and only sending bones that are not their default value. This reduces avatar pose data to about 25% of what it was, which significantly reduces load when several avatars are present (worked with up to 5 players!). This change also adjusts timeline parameters to be more robust toward minor lag and catches and discards some bad controller pose data before it goes to IK. The server now outputs average timeline network usage every 10 seconds.